### PR TITLE
Speed things up

### DIFF
--- a/parkersolarwind/parkersolarwind.py
+++ b/parkersolarwind/parkersolarwind.py
@@ -6,6 +6,7 @@ import numpy as np
 import scipy.optimize as opt
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
+import numba
 
 ##### ISOTHERMAL PARKER SOLAR WIND
 
@@ -30,6 +31,7 @@ def critical_radius_fext(f_ext,T_coronal=2e+6*u.K,mu=0.5) :
         )
     return opt.root(transcendental,0.5*critical_radius(T_coronal,mu=mu)).x[0]*u.R_sun
 
+@numba.njit(cache=True)
 def parker_isothermal(uu,r,u_c,r_c) :
     return ((uu/u_c)**2 -1) - np.log((uu/u_c)**2) - 4*np.log(r/r_c) -4*(r_c/r-1)
 
@@ -207,6 +209,7 @@ def get_uc_crit_fext(sc, fext, r0=1*u.R_sun) :
                       ).to(u.km**2/u.s**2).value/(2*ug**2))**-1
     return get_ug(r0)/np.sqrt(s_prime)
 
+@numba.njit(cache=True)
 def parker_polytropic(u_,r_, u0_, uc0_, ug_, gamma_, r0_) :
     term1 = 0.5 * (u_**2 - u0_**2)
     term2 = uc0_**2/(gamma_-1) * (((u0_*r0_**2)/(u_*r_**2))**(gamma_-1) - 1)

--- a/parkersolarwind/parkersolarwind.py
+++ b/parkersolarwind/parkersolarwind.py
@@ -259,22 +259,24 @@ def solve_parker_polytropic(
     # Solve Bernouilli's equation
     u_sol_polytropic = []
     uguess = [u0.to("km/s").value,uc_crit.to("km/s").value*1.1]
-    for ii,R in enumerate(R_sol) : 
+    # Do the unit conversions outside the loop
+    args = (u0.to("km/s").value,
+            uc0.to("km/s").value,
+            ug.to("km/s").value,
+            gamma,
+            r0.to("R_sun").value
+           )
+    r_crit_val = r_crit.to("R_sun").value
+    for R in R_sol.to("R_sun").value :
         sol = opt.root(parker_polytropic,
                        uguess,
-                       args=(R.to("R_sun").value,
-                             u0.to("km/s").value,
-                             uc0.to("km/s").value,
-                             ug.to("km/s").value,
-                             gamma,
-                             r0.to("R_sun").value
-                             )
+                       args=(R,) + args
                       )
         if sol.message == 'The solution converged.' :
-            uguessnext=sorted(list(sol.x))
+            uguessnext=sorted(sol.x)
             uguess=uguessnext
         else : uguessnext = [np.nan]*2
-        if R < r_crit : u_sol_polytropic.append(uguessnext[-2])
+        if R < r_crit_val : u_sol_polytropic.append(uguessnext[-2])
         else : u_sol_polytropic.append(uguessnext[-1])
     u_sol_polytropic = np.array(u_sol_polytropic) * u.km/u.s
     u_sol_polytropic[0] = u0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 	"matplotlib >= 3.6",
 	"numpy >= 1.21",
 	"scipy >= 1.8",
+  "numba >= 0.58",
 ]
 requires-python = " >= 3.8"
 description ="Python code to produce Parker solar wind solutions (isothermal, polytropic and isotherm-polytrope 2-layer)"


### PR DESCRIPTION
Hi Sam, I'm using the parameters of an isothermal-layer model as parameters to be fit to make the model match observations, so I'm running your code many times and would like it to be faster. This PR makes it faster.

(I don't just want a fast solar wind, I want a solar wind fast!)

The main time cost was the loop in solve_parker_polytropic, and most of that time was doing unit conversions afresh each time through the loop. I've reduced the work to be done in that loop as much as possible, for good time savings. It takes my fitting routine down from 3m51s to 1m14s for a sample run (which ends up computing 2700 wind models).

The profiling for that loop looked like this, where the first column is the percentage of time spent on that line:
```
          # Solve Bernouilli's equation
 0.0      u_sol_polytropic = []
 0.1      uguess = [u0.to("km/s").value,uc_crit.to("km/s").value*1.1]
 1.0      for ii,R in enumerate(R_sol) : 
20.1          sol = opt.root(parker_polytropic,
 0.0                         uguess,
 3.3                         args=(R.to("R_sun").value,
23.4                               u0.to("km/s").value,
21.8                               uc0.to("km/s").value,
21.6                               ug.to("km/s").value,
 0.0                               gamma,
 3.0                               r0.to("R_sun").value
                                   )
                            )
 0.2          if sol.message == 'The solution converged.' :
 0.5              uguessnext=sorted(list(sol.x))
 0.0              uguess=uguessnext
              else : uguessnext = [np.nan]*2
 2.4          if R < r_crit : u_sol_polytropic.append(uguessnext[-2])
 0.1          else : u_sol_polytropic.append(uguessnext[-1])
 0.0      u_sol_polytropic = np.array(u_sol_polytropic) * u.km/u.s
 0.0      u_sol_polytropic[0] = u0
```
After, it looks like this:
```
          # Solve Bernouilli's equation
 0.0      u_sol_polytropic = []
 0.2      uguess = [u0.to("km/s").value,uc_crit.to("km/s").value*1.1]
          # Do the unit conversions outside the loop
 0.1      args = (u0.to("km/s").value,
 0.1              uc0.to("km/s").value,
 0.1              ug.to("km/s").value,
 0.0              gamma,
 0.0              r0.to("R_sun").value
                  )
 0.0      r_crit_val = r_crit.to("R_sun").value
 0.2      for R in R_sol.to("R_sun").value :
84.4          sol = opt.root(parker_polytropic,
 0.1                         uguess,
 0.2                         args=(R,) + args
                            )
 0.8          if sol.message == 'The solution converged.' :
 1.4              uguessnext=sorted(sol.x)
 0.1              uguess=uguessnext
              else : uguessnext = [np.nan]*2
 0.2          if R < r_crit_val : u_sol_polytropic.append(uguessnext[-2])
 0.3          else : u_sol_polytropic.append(uguessnext[-1])
 0.1      u_sol_polytropic = np.array(u_sol_polytropic) * u.km/u.s
 0.1      u_sol_polytropic[0] = u0
```

Next I applied `numba` to a few of the key math functions (the ones whose roots need to be found numerically). `numba` automatically converts Python functions to C and compiles them, so there's a lot of benefit when applied judiciously. Applying it to `parker_polytropic`took my fitting routine down from 1m14s to 35s, and then applying it to `parker_isothermal` got me down to 25s. This does add a dependency, but I think numba usually works well without any hassles.